### PR TITLE
Proposal of correction to have the tool able to compile kernel v4.16 and above

### DIFF
--- a/compile_linux_kernel.sh
+++ b/compile_linux_kernel.sh
@@ -21,7 +21,7 @@ OPTIND=1
 
 # Set overlap variables
 DEPENDENCIES+="bc build-essential gnupg libnotify-bin libssl-dev pkg-config \
-				time "
+				time bison flex "
 
 # shellcheck disable=SC2034
 BASEURL=kernel.org

--- a/compile_linux_kernel.sh
+++ b/compile_linux_kernel.sh
@@ -145,7 +145,7 @@ if [[ ! $REPLY  =~ ^[Yy]$ ]]; then
 	MSG="sudo dpkg -i $pDir/*.deb"
 	center-text "${Yellow}" "${MSG}" "${Reg}"
 	echo -e "\nYou will still have to handle the installation of modules from the source directory with:"
-	MSG="sudo modules_install"
+	MSG="sudo make modules_install"
 	center-text "${Yellow}" "${MSG}" "${Reg}"
 	echo -e "\n${Yellow}[!]${Reg} Skipping kernel and modules installation . . ."
 else

--- a/remove_old_kernels.sh
+++ b/remove_old_kernels.sh
@@ -54,7 +54,7 @@ if [ $AV -eq 1 ]; then
 	fi
 fi
 
-dpkg -l linux-* | awk '/^ii/{ print $2}' | grep -v -e "$(uname -r | cut -f1,2 -d"-")" | grep -e "[0-9]" | grep -E "(image|headers)" | xargs $SUDO apt-get -y purge
+dpkg -l "linux-*" | awk '/^ii/{ print $2}' | grep -v -e "$(uname -r | cut -f1,2 -d"-")" | grep -e "[0-9]" | grep -E "(image|headers)" | xargs $SUDO apt-get -y purge
 
 # Used to temporarily disable Sophos AntiVirus
 if [ -s $HOME/.aliases/sophos ]; then


### PR DESCRIPTION
Hello,

First, thank you so much for your tool. It saved me a lot of time.

Since _kernel version 4.16_, **compile_linux_kernel.sh** generates an error.
By adding the check and installation of packages bison and flex, **compile_linux_kernel.sh** works again with kernel vesion 4.16 and above.

I have used this modification on 2 debian computers, and it went OK.

I found the solution here : [https://www.linuxquestions.org/questions/debian-26/compile-of-kernel-4-16-fails-4175628085/](url)
Hope it helps.

Regards